### PR TITLE
Add project scaffolding and configuration loader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+# Python cache and build artifacts
+__pycache__/
+*.py[cod]
+*.egg-info/
+build/
+dist/
+
+# Virtual environments
+.venv/
+.env/
+
+# Local cache for cloned contribution repositories
+.cache/
+
+# IDE settings
+.vscode/
+.idea/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,29 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "contribution-adder"
+version = "0.1.0"
+description = "Automation utilities for generating GitHub contribution commits."
+readme = "README.md"
+authors = [
+    { name = "Automation Bot" }
+]
+license = { text = "MIT" }
+requires-python = ">=3.11"
+dependencies = [
+    "GitPython>=3.1"
+]
+
+[project.optional-dependencies]
+dotenv = ["python-dotenv>=1.0"]
+
+[project.urls]
+Homepage = "https://example.com/contribution-adder"
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/src/contribution_adder/__init__.py
+++ b/src/contribution_adder/__init__.py
@@ -1,0 +1,16 @@
+"""Top-level package for the contribution adder project."""
+
+from importlib import metadata
+
+__all__ = ["__version__"]
+
+
+def _get_version() -> str:
+    """Return the installed package version or a default placeholder."""
+    try:
+        return metadata.version("contribution-adder")
+    except metadata.PackageNotFoundError:  # pragma: no cover - fallback for editable installs
+        return "0.0.0"
+
+
+__version__ = _get_version()

--- a/src/contribution_adder/config.py
+++ b/src/contribution_adder/config.py
@@ -1,0 +1,85 @@
+"""Configuration loading utilities for the contribution adder service."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+from pathlib import Path
+from typing import Mapping
+
+try:  # pragma: no cover - optional dependency handling
+    from dotenv import load_dotenv
+except ModuleNotFoundError:  # pragma: no cover - executed when extra is not installed
+    load_dotenv = None  # type: ignore[assignment]
+
+ENV_TARGET_REPO = "TARGET_REPO"
+ENV_TOKEN = "CONTRIB_PAT"
+
+
+@dataclass(slots=True)
+class AppConfig:
+    """Concrete settings required to run the contribution adder workflow."""
+
+    target_repo: str
+    token: str
+
+
+def _load_dotenv_if_available(dotenv_path: str | os.PathLike[str] | None) -> None:
+    """Load environment variables from a ``.env`` file when python-dotenv is installed."""
+
+    if load_dotenv is None:
+        return
+
+    candidate = Path(dotenv_path) if dotenv_path is not None else Path.cwd() / ".env"
+    if candidate.exists():
+        load_dotenv(dotenv_path=str(candidate), override=False)
+
+
+def load_config(
+    env: Mapping[str, str] | None = None,
+    *,
+    dotenv_path: str | os.PathLike[str] | None = None,
+) -> AppConfig:
+    """Load configuration from environment variables and optional ``.env`` file.
+
+    Parameters
+    ----------
+    env:
+        Optional mapping used for environment lookups. When provided, ``os.environ``
+        is not read, enabling deterministic tests.
+    dotenv_path:
+        Explicit path to a ``.env`` file. When omitted, the loader searches for a
+        file named ``.env`` in the current working directory.
+
+    Returns
+    -------
+    AppConfig
+        A populated configuration object.
+
+    Raises
+    ------
+    RuntimeError
+        If any required variables are missing.
+    """
+
+    if env is None:
+        _load_dotenv_if_available(dotenv_path)
+        env_mapping: Mapping[str, str] = os.environ
+    else:
+        env_mapping = env
+
+    target_repo = env_mapping.get(ENV_TARGET_REPO)
+    token = env_mapping.get(ENV_TOKEN)
+
+    missing = [name for name, value in ((ENV_TARGET_REPO, target_repo), (ENV_TOKEN, token)) if not value]
+    if missing:
+        missing_list = ", ".join(missing)
+        raise RuntimeError(
+            "Missing required environment variable(s): "
+            f"{missing_list}. Ensure they are set or provided via a .env file."
+        )
+
+    return AppConfig(target_repo=target_repo or "", token=token or "")
+
+
+__all__ = ["AppConfig", "ENV_TARGET_REPO", "ENV_TOKEN", "load_config"]


### PR DESCRIPTION
## Summary
- add setuptools-based pyproject that exposes the contribution-adder package
- introduce package initializer and configuration loader with optional .env support
- configure gitignore for caches, build outputs, and virtual environments

## Testing
- pip install -e .

------
https://chatgpt.com/codex/tasks/task_e_68dce6aac6e4832b9110ce1d84cffc01