### PR TITLE
Add deterministic prime selection utilities

### DIFF
--- a/src/contribution_adder/primes.py
+++ b/src/contribution_adder/primes.py
@@ -1,0 +1,60 @@
+"""Utility functions for selecting and summing small prime numbers."""
+
+from __future__ import annotations
+
+import random
+
+PRIMES_UNDER_30: tuple[int, ...] = (
+    2,
+    3,
+    5,
+    7,
+    11,
+    13,
+    17,
+    19,
+    23,
+    29,
+)
+"""A tuple containing all prime numbers less than 30."""
+
+
+def pick_two_primes(random_seed: int | None = None) -> tuple[int, int]:
+    """Return a deterministic pair of distinct primes under 30.
+
+    Args:
+        random_seed: Optional seed value to initialize the pseudorandom number
+            generator. Providing a seed guarantees deterministic output across
+            invocations, which is especially useful in unit tests.
+
+    Returns:
+        A tuple of two distinct prime numbers.
+
+    Raises:
+        ValueError: If the global prime pool is empty or contains fewer than two
+            primes, making selection impossible.
+    """
+
+    if len(PRIMES_UNDER_30) < 2:
+        raise ValueError("At least two primes are required for selection.")
+
+    rng = random.Random(random_seed)
+    selection = rng.sample(PRIMES_UNDER_30, k=2)
+    return selection[0], selection[1]
+
+
+def sum_primes(prime_pair: tuple[int, int]) -> int:
+    """Return the sum of a pair of prime numbers.
+
+    Args:
+        prime_pair: The pair of prime numbers to be summed.
+
+    Returns:
+        The arithmetic sum of the provided prime numbers.
+    """
+
+    first, second = prime_pair
+    return first + second
+
+
+__all__ = ["PRIMES_UNDER_30", "pick_two_primes", "sum_primes"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,11 @@
+"""Pytest configuration for the contribution adder project."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SRC_DIR = PROJECT_ROOT / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))

--- a/tests/test_primes.py
+++ b/tests/test_primes.py
@@ -1,0 +1,33 @@
+"""Tests for the prime selection utilities."""
+
+from __future__ import annotations
+
+import pytest
+
+from contribution_adder import primes
+
+
+def test_pick_two_primes_is_deterministic_with_seed() -> None:
+    """Repeated calls with the same seed should return the same ordered pair."""
+
+    first_selection = primes.pick_two_primes(random_seed=42)
+    second_selection = primes.pick_two_primes(random_seed=42)
+
+    assert first_selection == second_selection
+    assert all(prime in primes.PRIMES_UNDER_30 for prime in first_selection)
+    assert first_selection[0] != first_selection[1]
+
+
+def test_sum_primes_adds_numbers() -> None:
+    """The helper should sum the pair element-wise."""
+
+    assert primes.sum_primes((3, 11)) == 14
+
+
+def test_pick_two_primes_raises_when_pool_insufficient(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Sampling should fail when the available prime pool is too small."""
+
+    monkeypatch.setattr(primes, "PRIMES_UNDER_30", ())
+
+    with pytest.raises(ValueError):
+        primes.pick_two_primes()


### PR DESCRIPTION
## Summary
- add a prime utilities module with deterministic selection and sum helpers
- configure pytest to locate the source tree without installation
- cover the new prime logic with focused unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e43bcc568c832ba2c5280dd1d3376b