### PR TITLE
Add contribution runner orchestration workflow

### DIFF
--- a/src/contribution_adder/__main__.py
+++ b/src/contribution_adder/__main__.py
@@ -1,0 +1,40 @@
+"""Command line interface for the contribution adder package."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from pathlib import Path
+from typing import Sequence
+
+from .contribution_runner import ContributionRunner
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run the contribution adder workflow.")
+    parser.add_argument("--seed", type=int, default=None, help="Optional RNG seed for deterministic commit counts.")
+    parser.add_argument(
+        "--worktree",
+        type=Path,
+        default=None,
+        help="Directory used for the cached repository clone (defaults to .cache/contribution_repo).",
+    )
+    parser.add_argument(
+        "--branch",
+        default="main",
+        help="Branch name the runner should operate on (defaults to main).",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    runner = ContributionRunner(worktree_dir=args.worktree, random_seed=args.seed, default_branch=args.branch)
+    runner.run()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()

--- a/src/contribution_adder/contribution_runner.py
+++ b/src/contribution_adder/contribution_runner.py
@@ -1,0 +1,191 @@
+"""High-level orchestration for generating automated contribution commits."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import logging
+from pathlib import Path
+import time
+from typing import Callable
+
+from git import GitCommandError, Repo
+
+from .config import AppConfig, load_config
+from .primes import pick_two_primes, sum_primes
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class RunnerDependencies:
+    """Convenience wrapper that groups injectable dependencies.
+
+    Dependency injection keeps :class:`ContributionRunner` testable by allowing
+    unit tests to replace components such as the configuration loader or prime
+    utilities without resorting to monkeypatching global symbols.
+    """
+
+    config_loader: Callable[[], AppConfig] = load_config
+    prime_picker: Callable[[int | None], tuple[int, int]] = pick_two_primes
+    prime_summer: Callable[[tuple[int, int]], int] = sum_primes
+    sleep: Callable[[float], None] = time.sleep
+
+
+class ContributionRunner:
+    """Coordinate cloning, committing, and pushing contributions to a repo."""
+
+    def __init__(
+        self,
+        *,
+        worktree_dir: str | Path | None = None,
+        remote_override: str | None = None,
+        default_branch: str = "main",
+        random_seed: int | None = None,
+        dependencies: RunnerDependencies | None = None,
+        logger: logging.Logger | None = None,
+        max_push_attempts: int = 3,
+    ) -> None:
+        self._worktree_dir = Path(worktree_dir) if worktree_dir else Path(".cache") / "contribution_repo"
+        self._remote_override = remote_override
+        self._default_branch = default_branch
+        self._random_seed = random_seed
+        self._deps = dependencies or RunnerDependencies()
+        self._logger = logger or LOGGER
+        self._max_push_attempts = max_push_attempts
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def run(self) -> None:
+        """Execute the contribution workflow end-to-end."""
+
+        config = self._deps.config_loader()
+        repo = self._prepare_repository(config)
+        self._ensure_user_config(repo)
+
+        prime_pair = self._deps.prime_picker(self._random_seed)
+        commit_count = self._deps.prime_summer(prime_pair)
+        if commit_count <= 0:
+            self._logger.info("Computed non-positive commit count; skipping run.")
+            return
+
+        self._logger.info("Generating %s commits based on prime pair %s.", commit_count, prime_pair)
+        log_path = Path(repo.working_tree_dir or self._worktree_dir) / "contribution-log.txt"
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+
+        for iteration in range(1, commit_count + 1):
+            self._append_log_entry(log_path, iteration, commit_count)
+            repo.index.add([str(log_path)])
+            message = f"chore: automated contribution {iteration}/{commit_count}"
+            repo.index.commit(message)
+            self._logger.debug("Created commit %s/%s with message %s", iteration, commit_count, message)
+
+        self._push_with_retries(repo)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _prepare_repository(self, config: AppConfig) -> Repo:
+        """Clone the repository if needed and ensure the working tree is ready."""
+
+        remote_url = self._build_remote_url(config)
+        worktree = self._worktree_dir
+        worktree.parent.mkdir(parents=True, exist_ok=True)
+
+        if worktree.exists() and (worktree / ".git").exists():
+            repo = Repo(worktree)
+            self._logger.debug("Using existing repository at %s", worktree)
+            origin = repo.remotes.origin
+            origin.fetch()
+        else:
+            self._logger.info("Cloning repository %s into %s", config.target_repo, worktree)
+            repo = Repo.clone_from(remote_url, worktree)
+            origin = repo.remotes.origin
+
+        self._checkout_branch(repo)
+        self._pull_latest(origin)
+        self._ensure_upstream(repo)
+        return repo
+
+    def _build_remote_url(self, config: AppConfig) -> str:
+        if self._remote_override:
+            return self._remote_override
+
+        token = config.token
+        sanitized_repo = config.target_repo
+        if not sanitized_repo:
+            raise RuntimeError("Target repository cannot be empty.")
+
+        return f"https://{token}@github.com/{sanitized_repo}.git"
+
+    def _checkout_branch(self, repo: Repo) -> None:
+        branch = self._default_branch
+        try:
+            repo.git.checkout(branch)
+        except GitCommandError:
+            remote_branch = f"origin/{branch}"
+            if remote_branch in {ref.name for ref in repo.refs}:
+                repo.git.checkout("-B", branch, remote_branch)
+            else:
+                repo.git.checkout("-B", branch)
+
+    def _pull_latest(self, origin) -> None:
+        branch = self._default_branch
+        remote_branch = f"origin/{branch}"
+        try:
+            remote_refs = {ref.name for ref in origin.refs}
+            if remote_branch in remote_refs:
+                origin.pull(branch)
+        except GitCommandError as exc:
+            self._logger.warning("Failed to pull latest changes: %s", exc)
+
+    def _ensure_user_config(self, repo: Repo) -> None:
+        config_writer = repo.config_writer()
+        config_reader = repo.config_reader()
+        try:
+            config_reader.get_value("user", "name")
+        except Exception:  # pragma: no cover - configparser edge cases
+            config_writer.set_value("user", "name", "Contribution Adder Bot")
+        try:
+            config_reader.get_value("user", "email")
+        except Exception:  # pragma: no cover - configparser edge cases
+            config_writer.set_value("user", "email", "contribution-adder@example.com")
+
+    def _append_log_entry(self, log_path: Path, iteration: int, total: int) -> None:
+        from datetime import datetime, timezone
+
+        timestamp = datetime.now(tz=timezone.utc).isoformat()
+        entry = f"{timestamp} - automated contribution {iteration}/{total}"
+        with log_path.open("a", encoding="utf-8") as handle:
+            handle.write(entry + "\n")
+
+    def _ensure_upstream(self, repo: Repo) -> None:
+        branch = self._default_branch
+        remote_branch = f"origin/{branch}"
+        if remote_branch in {ref.name for ref in repo.refs}:
+            try:
+                repo.git.branch("--set-upstream-to", remote_branch, branch)
+            except GitCommandError:
+                self._logger.debug("Unable to set upstream for branch %s", branch)
+
+    def _push_with_retries(self, repo: Repo) -> None:
+        origin = repo.remotes.origin
+        last_error: GitCommandError | None = None
+        refspec = f"{self._default_branch}:{self._default_branch}"
+        for attempt in range(1, self._max_push_attempts + 1):
+            try:
+                origin.push(refspec=refspec)
+                self._logger.info("Pushed changes on attempt %s", attempt)
+                return
+            except GitCommandError as exc:
+                last_error = exc
+                self._logger.warning("Push attempt %s failed: %s", attempt, exc)
+                if attempt < self._max_push_attempts:
+                    delay = min(2 ** (attempt - 1), 30)
+                    self._deps.sleep(delay)
+
+        if last_error is not None:
+            raise last_error
+
+
+__all__ = ["ContributionRunner", "RunnerDependencies"]

--- a/tests/test_contribution_runner.py
+++ b/tests/test_contribution_runner.py
@@ -1,0 +1,84 @@
+"""Tests for the :mod:`contribution_adder.contribution_runner` module."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Callable
+
+import pytest
+from git import GitCommandError, Repo
+from git.remote import Remote
+
+from contribution_adder.config import AppConfig
+from contribution_adder.contribution_runner import ContributionRunner, RunnerDependencies
+
+
+def _config_loader_factory(target_repo: str, token: str) -> Callable[[], AppConfig]:
+    def _loader() -> AppConfig:
+        return AppConfig(target_repo=target_repo, token=token)
+
+    return _loader
+
+
+def test_runner_creates_expected_commits(tmp_path: Path) -> None:
+    remote_path = tmp_path / "remote.git"
+    Repo.init(remote_path, bare=True)
+
+    worktree = tmp_path / "worktree"
+    dependencies = RunnerDependencies(
+        config_loader=_config_loader_factory("example/repo", "token"),
+        prime_picker=lambda seed: (2, 3),
+        prime_summer=lambda pair: sum(pair),
+        sleep=lambda seconds: None,
+    )
+
+    runner = ContributionRunner(
+        worktree_dir=worktree,
+        remote_override=str(remote_path),
+        random_seed=42,
+        dependencies=dependencies,
+    )
+
+    runner.run()
+
+    log_path = worktree / "contribution-log.txt"
+    lines = [line for line in log_path.read_text(encoding="utf-8").splitlines() if line.strip()]
+    assert len(lines) == 5
+
+    remote_repo = Repo(remote_path)
+    commit_count = int(remote_repo.git.rev_list("--count", "refs/heads/main"))
+    assert commit_count == 5
+
+
+def test_runner_retries_push(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    remote_path = tmp_path / "remote.git"
+    Repo.init(remote_path, bare=True)
+    worktree = tmp_path / "worktree"
+
+    dependencies = RunnerDependencies(
+        config_loader=_config_loader_factory("example/repo", "token"),
+        prime_picker=lambda seed: (2, 3),
+        prime_summer=lambda pair: 1,
+        sleep=lambda seconds: None,
+    )
+
+    runner = ContributionRunner(
+        worktree_dir=worktree,
+        remote_override=str(remote_path),
+        dependencies=dependencies,
+        max_push_attempts=3,
+    )
+
+    attempts = {"count": 0}
+
+    def fake_push(self: Remote, *args, **kwargs):
+        attempts["count"] += 1
+        if attempts["count"] < 3:
+            raise GitCommandError("push", 1, stderr="simulated failure")
+        return []
+
+    monkeypatch.setattr(Remote, "push", fake_push)
+
+    runner.run()
+
+    assert attempts["count"] == 3


### PR DESCRIPTION
## Summary
- implement a ContributionRunner that clones the target repository, appends log entries, and pushes commits with retries
- expose a CLI entry point so the automation can be triggered with python -m contribution_adder
- add pytest coverage verifying commit generation and push retry behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e43daa62d8832b92949039d101d90d