### PR TITLE
Add scheduled workflow for contribution runner

### DIFF
--- a/.github/workflows/contribution-adder.yml
+++ b/.github/workflows/contribution-adder.yml
@@ -1,0 +1,30 @@
+name: Contribution Adder
+
+on:
+  schedule:
+    - cron: '5 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  run-contribution-adder:
+    name: Run contribution adder
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: pip install -e '.[dotenv]'
+
+      - name: Execute contribution adder
+        env:
+          TARGET_REPO: ${{ secrets.TARGET_REPO }}
+          CONTRIB_PAT: ${{ secrets.CONTRIB_PAT }}
+        run: python -m contribution_adder


### PR DESCRIPTION
## Summary
- add a scheduled and manually-triggered workflow to run the contribution adder
- cache pip dependencies and run the package with secrets-provided configuration

## Testing
- ./bin/act -l

------
https://chatgpt.com/codex/tasks/task_e_68e55f0eb0a4832b9aa1f55280a5cf23