### PR TITLE
[codex] Skip unconfigured contribution runs

### DIFF
--- a/.github/workflows/contribution-adder.yml
+++ b/.github/workflows/contribution-adder.yml
@@ -23,7 +23,21 @@ jobs:
       - name: Install dependencies
         run: pip install -e '.[dotenv]'
 
+      - name: Check contribution adder configuration
+        id: config
+        env:
+          HAS_TARGET_REPO: ${{ secrets.TARGET_REPO != '' }}
+          HAS_CONTRIB_PAT: ${{ secrets.CONTRIB_PAT != '' }}
+        run: |
+          if [ "$HAS_TARGET_REPO" = "true" ] && [ "$HAS_CONTRIB_PAT" = "true" ]; then
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            echo "::notice title=Contribution adder skipped::Set TARGET_REPO and CONTRIB_PAT repository secrets to enable scheduled runs."
+          fi
+
       - name: Execute contribution adder
+        if: steps.config.outputs.configured == 'true'
         env:
           TARGET_REPO: ${{ secrets.TARGET_REPO }}
           CONTRIB_PAT: ${{ secrets.CONTRIB_PAT }}


### PR DESCRIPTION
## Summary
- add a workflow preflight that checks whether `TARGET_REPO` and `CONTRIB_PAT` secrets are configured
- skip the scheduled contribution run with an Actions notice when those secrets are missing
- keep the existing `python -m contribution_adder` execution path unchanged once both secrets are present

## Root cause
The scheduled workflow always executed the CLI. In an unconfigured repository, GitHub expands missing secrets to empty values, so the app raises its intended missing-config `RuntimeError` and the scheduled Action fails every run.

## Verification
- `python -m pytest -q`
- `git diff --check`
- parsed `.github/workflows/contribution-adder.yml` with PyYAML and verified the config step id plus execute-step condition

## Notes
- GitHub's stored logs for the old failing run are expired (`HTTP 410`), so the root cause is inferred from the workflow command path and local reproduction of the missing-secret runtime error.